### PR TITLE
Require subr-x for string functions, and fix a typo.

### DIFF
--- a/company-dict.el
+++ b/company-dict.el
@@ -17,6 +17,7 @@
 
 (require 'company)
 (eval-when-compile (require 'cl-lib))
+(eval-when-compile (require 'subr-x))
 
 (defgroup company-dict nil
   "A backend that mimics ac-source-dictionary, with support for annotations and
@@ -70,7 +71,7 @@ documentation."
   (let ((file (expand-file-name (symbol-name mode) company-dict-dir))
         result)
     (unless (gethash mode company-dict-table)
-      (awhen (company-dict--read-file file)
+      (when (company-dict--read-file file)
         (mapc (lambda (line)
                 (unless (string-empty-p line)
                   (let ((l (split-string (string-trim-right line) "\t" t)))


### PR DESCRIPTION
The `subr-x` module is required for string manipulation functions. I get the following error message on configuring company-dict.

> Company backend ’company-dict’ could not be initialized:
> Symbol’s function definition is void: string-empty-p

Also fixed a typo with `when`.
